### PR TITLE
fix: profiler for VR

### DIFF
--- a/include/GrassControl/Main.h
+++ b/include/GrassControl/Main.h
@@ -89,22 +89,23 @@ namespace GrassControl
 			// 5923
 			struct GrassCreationEnd
 			{
-				static void thunk()
+				static DWORD thunk()
 				{
-					func();
+					// func(); This is GetCurrentThreadId() but has an access error in SE;
 					profiler->End();
+					return GetCurrentThreadId();
 				}
 				static inline REL::Relocation<decltype(thunk)> func;
 			};
 
 			static void Install()
 			{
-				stl::write_thunk_call<MainUpdate_Nullsub>(RELOCATION_ID(35565, 36564).address() + OFFSET_3(0x748, 0xC26, 0x7EE));
+				stl::write_thunk_call<MainUpdate_Nullsub>(RELOCATION_ID(35565, 36564).address() + OFFSET_3(0x748, 0xC2b, 0x7EE));
 				if (Config::ProfilerReport) {
-					stl::write_thunk_call<ConsoleOpen>(RELOCATION_ID(50155, 51082).address() + OFFSET_3(334, 334, 0x15b));
-					stl::write_thunk_call<GrassCreationStart>(RELOCATION_ID(13148, 13288).address() + OFFSET(0x905, 0x905));
+					stl::write_thunk_call<ConsoleOpen>(RELOCATION_ID(50155, 51082).address() + OFFSET_3(0x14E, 334, 0x15b));
+					stl::write_thunk_call<GrassCreationStart>(RELOCATION_ID(13148, 13288).address() + OFFSET(0x905, 0xb29));
 					stl::write_thunk_jump<GrassCreationStart>(RELOCATION_ID(13138, 13278).address() + OFFSET(0xF, 0xF));
-					stl::write_thunk_call<GrassCreationEnd>(RELOCATION_ID(15204, 15372).address() + OFFSET(3037, 3037));
+					stl::write_thunk_call<GrassCreationEnd, 6>(RELOCATION_ID(15204, 15372).address() + OFFSET(0xBDD, 0xbd9));
 				}
 			}
 		};

--- a/include/PCH.h
+++ b/include/PCH.h
@@ -62,11 +62,11 @@ namespace stl
 		T::func = trampoline.write_branch<5>(a_src, T::thunk);
 	}
 
-	template <class T>
+	template <class T, size_t size = 5>
 	void write_thunk_call(std::uintptr_t a_src)
 	{
 		auto& trampoline = SKSE::GetTrampoline();
-		T::func = trampoline.write_call<5>(a_src, T::thunk);
+		T::func = trampoline.write_call<size>(a_src, T::thunk);
 	}
 
 	template <class F, size_t offset, class T>


### PR DESCRIPTION
Note, AE appears to be broken, but I don't think it actually ever worked with `Profiler-report = true`. The functions do not match SE addresses at least with AE 1130. I have made some slight modifications to AE addresses, but those were for AE1130 and should be checked with 1170. The CTD on startup appears to be tied to `ConsoleOpen`'s hooked function `func(playerCharacter*)` that was inlined by AE1130.