### PR TITLE
build: fix vr build due to missing define

### DIFF
--- a/include/GrassControl/Main.h
+++ b/include/GrassControl/Main.h
@@ -100,7 +100,7 @@ namespace GrassControl
 
 			static void Install()
 			{
-				bool marketplace = REL::Module::get().version() >= SKSE::RUNTIME_1_6_1130;
+				bool marketplace = OFFSET(false, REL::Module::get().version() >= SKSE::RUNTIME_1_6_1130);
 				stl::write_thunk_call<MainUpdate_Nullsub>(RELOCATION_ID(35565, 36564).address() + OFFSET_3(0x748, (marketplace ? 0xC2b : 0xC26), 0x7EE));
 
 				if (Config::ProfilerReport) {


### PR DESCRIPTION
Probably fixes SE too as the version is only defined with AE support.

https://github.com/powerof3/CommonLibSSE/blob/26015a042947ef3787eac754d559e9653c664a2c/include/SKSE/Version.h#L24